### PR TITLE
Wrong 'git mv', dir. hierarchy fix [87757] and new -t/trial_run option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ pm_to_blib
 MYMETA.json
 MYMETA.yml
 Makefile.old
+*.sw[op]
+tags

--- a/eg/module-rename
+++ b/eg/module-rename
@@ -11,15 +11,16 @@ use Module::Rename;
 use Log::Log4perl qw(:easy);
 use Getopt::Std;
 use File::Basename;
+use Data::Dumper;
 
-getopts("vgh", \my %o);
+getopts("vght", \my %o);
 
 Log::Log4perl->easy_init({
   level  => $WARN,
   layout => "%m%n",
 });
 
-my  $VERSION = "0.01";
+my  $VERSION = "0.02";
 
 pod2usage({-message => basename($0) . " v$VERSION",
            -verbose => 2
@@ -34,6 +35,7 @@ my $ren = Module::Rename->new(
     name_new           => $new,
     wipe_empty_subdirs => 1,
     use_git            => $o{g},
+    trial_run          => $o{t},
 );
 
 $ren->find_and_rename($dir || ".");
@@ -46,7 +48,7 @@ __END__
 
 =head1 SYNOPSIS
 
-    $ module-rename Old::Name New::Name Old-Name-Distro-Dir
+    module-rename [-v|-g|-h|-t] Old::Name New::Name Old-Name-Distro-Dir
 
 =head1 DESCRIPTION
 
@@ -109,11 +111,16 @@ Verbose mode.
 
 =item B<-h>
 
-Show the script's version and manual page.
+Show this manual page.
 
 =item B<-g>
 
 Move files using "git mv" instead of "mv".
+
+=item B<-t>
+
+Trial run - Don't change anything, just display actions that would have
+occurred without the -t option.
 
 =back
 

--- a/lib/Module/Rename.pm
+++ b/lib/Module/Rename.pm
@@ -36,6 +36,7 @@ sub new {
         push @{ $self->{dir_exclude} }, ".git";
     }
 
+    $self->{name_old} = '\b' . $self->{name_old} . '\b';
     $self->{dir_exclude_hash} = { map { $_ => 1 } @{$self->{dir_exclude}} };
     $self->{dir_ignore_hash}  = { map { $_ => 1 } @{$self->{dir_ignore}} };
 

--- a/lib/Module/Rename.pm
+++ b/lib/Module/Rename.pm
@@ -10,10 +10,13 @@ use File::Spec qw( splitdir );
 use Sysadm::Install qw(:all);
 use Log::Log4perl qw(:easy);
 use File::Spec::Functions qw( abs2rel splitdir );
+use Cwd;
 
-our $VERSION = "0.04";
+our $VERSION = "0.05";
 
 ###########################################
+# use_git   => Use 'git mv' instead of 'mv'.
+# trial_run => Report, but don't execute, changes.
 sub new {
 ###########################################
     my($class, %options) = @_;
@@ -25,6 +28,7 @@ sub new {
         dir_ignore         => ['CVS'],
         wipe_empty_subdirs => 0,
         use_git            => 0,
+        trial_run          => 0,
         %options,
     };
 
@@ -84,13 +88,26 @@ sub move {
               # make sure we launch the git command inside the git workspace
             my $common = $self->longest_common_path( $old_path, $new_path );
             cd $common;
-            tap("git", "mv", 
-               abs2rel( $old_path, $common ),
-               abs2rel( $new_path, $common ),
-            );
+            if ($self->{trial_run}) {
+                print "[in " . getcwd() . ":]\n";
+            }
+
+            if ($self->{trial_run}) {
+                print "git mv " . abs2rel( $old_path, $common ) . ' ' .
+                    abs2rel( $new_path, $common ) . "\n";
+            } else {
+                tap("git", "mv", 
+                    abs2rel( $old_path, $common ),
+                    abs2rel( $new_path, $common ),
+                );
+            }
             cdback;
         } else {
-            mv $old_path, $new_path;
+            if ($self->{trial_run}) {
+                print "mv $old_path $new_path\n"
+            } else {
+                mv $old_path, $new_path;
+            }
         }
     }
 }
@@ -118,7 +135,7 @@ sub find_and_rename {
                 $_ eq $self->{pmfile};
         $self->file_process($_, $File::Find::name);
     }, $start_dir);
-    
+
     for my $file (@files) {
 
         my $newfile = $file;
@@ -133,7 +150,7 @@ sub find_and_rename {
 
         INFO "mv $file $newfile";
         my $dir = dirname($newfile);
-        mkd $dir unless -d $dir;
+        mkd $dir unless -d $dir || $self->{trial_run};
         $self->move($file, $newfile);
     }
 
@@ -202,16 +219,29 @@ sub file_process {
     my $out = "";
 
     open FILE, "<$file" or LOGDIE "Can't open $file ($!)";
-    while(<FILE>) {
+    my $line_num = 0;
+    my $first_diff = 1;
+    while(my $line = <FILE>) {
+        ++$line_num;
         DEBUG "Looking for /$self->{name_old}/";
-        s/($self->{name_old})\b/$self->rep($1,$self->{name_new})/ge;
+        my $orig_line = $line;
+        $line =~ s/($self->{name_old})\b/$self->rep($1,$self->{name_new})/ge;
         DEBUG "Looking for /$self->{look_for}/";
-        s/($self->{look_for})\b/$self->rep($1,$self->{replace_by})/ge;
-        $out .= $_;
+        $line =~ s/($self->{look_for})\b/$self->rep($1,$self->{replace_by})/ge;
+        if ($self->{trial_run} and $line ne $orig_line) {
+            if ($first_diff) {
+                print "$file:\n";
+                $first_diff = 0;
+            }
+            print "${line_num}c${line_num}\n- $orig_line+ $line";
+        }
+        $out .= $line;
     }
     close FILE;
 
-    blurt $out, $file;
+    if (not $self->{trial_run}) {
+        blurt $out, $file;
+    }
 }
 
 ###########################################
@@ -344,6 +374,15 @@ but can be overridden.
 
 If set to a true value, 'empty' (see above) subdirectories will be deleted after
 all renaming and restructuring is done. Defaults to true.
+
+=item C<use_git>
+
+Perform a 'git mv' instead of the default, 'mv'.
+
+=item C<trial_run>
+
+Perform a "trial run" - report, but don't actually execute, the changes
+resulting from the Rename object configuration.
 
 =back
 


### PR DESCRIPTION
This branch includes a fix for the bug I reported at: https://rt.cpan.org/Public/Bug/Display.html?id=87757 (and also brought up in the discussion of bug https://rt.cpan.org/Public/Bug/Display.html?id=87172).  The branch also includes changes to implement a -t (trial_run - report, no changes) option.  I find this option quite helpful - and I suspect others will also - to check if a module-rename command I'm considering will do what I expect it to do before I actually execute it.  I've tested the changes by hand and found no problems.  Unfortunately, I don't have time (at least currently) to write automated tests for these changes.
