### PR TITLE
remove unhandled import arguments

### DIFF
--- a/lib/Module/Rename.pm
+++ b/lib/Module/Rename.pm
@@ -6,7 +6,7 @@ use strict;
 use warnings;
 use File::Find;
 use File::Basename;
-use File::Spec qw( splitdir );
+use File::Spec;
 use Sysadm::Install qw(:all);
 use Log::Log4perl qw(:easy);
 use File::Spec::Functions qw( abs2rel splitdir );


### PR DESCRIPTION
Previous versions of perl allow a use or import call even if the import method doesn't exist. Future versions are intending to throw errors for calls to an undefined import method that includes arguments.

Remove the arguments to use lines when the import method does not exist.